### PR TITLE
Handle WooCommerce specific queries to display results through ES

### DIFF
--- a/elasticpress-woocommerce.php
+++ b/elasticpress-woocommerce.php
@@ -251,6 +251,12 @@ function epwc_translate_args( $query ) {
 	 */
 	if ( ! empty( $query->query_vars['ep_integrate'] ) ) {
 
+		if ( has_filter( 'posts_clauses', array( WC()->query, 'order_by_rating_post_clauses' ) ) ) {
+			remove_filter( 'posts_clauses', array( WC()->query, 'order_by_rating_post_clauses' ) );
+			$query->set( 'orderby', 'meta_value_num' );
+			$query->set( 'meta_key', '_wc_average_rating' );
+		}
+
 		/**
 		 * Make sure filters are suppressed
 		 */

--- a/elasticpress-woocommerce.php
+++ b/elasticpress-woocommerce.php
@@ -202,10 +202,25 @@ function epwc_translate_args( $query ) {
 		if ( ! empty( $term ) ) {
 			$query->query_vars['ep_integrate'] = true;
 
+			$terms = array( $term );
+
+			// to add child terms to the tax query
+			if ( is_taxonomy_hierarchical( $taxonomy ) ) {
+				$term_object = get_term_by( 'slug', $term, $taxonomy );
+				$children    = get_term_children( $term_object->term_id, $taxonomy );
+				if ( $children ) {
+					foreach ( $children as $child ) {
+						$child_object = get_term( $child, $taxonomy );
+						$terms[]      = $child_object->slug;
+					}
+				}
+
+			}
+
 			$tax_query[] = array(
 				'taxonomy' => $taxonomy,
 				'field'    => 'slug',
-				'terms'    => array( $term ),
+				'terms'    => $terms,
 			);
 		}
 	}
@@ -265,10 +280,8 @@ function epwc_translate_args( $query ) {
 			$query->set( 'meta_query', $meta_query );
 		}
 
-		$post_parent = $query->get( 'post_parent', false );
-
-
-		if ( 'product' === $post_type ) {
+		// Assuming empty to be product post type
+		if ( empty( $post_type ) ) {
 			/**
 			 * Set orderby from GET param
 			 */

--- a/elasticpress-woocommerce.php
+++ b/elasticpress-woocommerce.php
@@ -280,8 +280,8 @@ function epwc_translate_args( $query ) {
 			$query->set( 'meta_query', $meta_query );
 		}
 
-		// Assuming empty to be product post type
-		if ( empty( $post_type ) ) {
+		// Assuming $post_type to be product if empty
+		if ( empty( $post_type ) || 'product' === $post_type ) {
 			/**
 			 * Set orderby from GET param
 			 */

--- a/elasticpress-woocommerce.php
+++ b/elasticpress-woocommerce.php
@@ -250,6 +250,7 @@ function epwc_translate_args( $query ) {
 	 * If we have an ElasticPress query, do the following:
 	 */
 	if ( ! empty( $query->query_vars['ep_integrate'] ) ) {
+
 		/**
 		 * Make sure filters are suppressed
 		 */
@@ -281,13 +282,13 @@ function epwc_translate_args( $query ) {
 		}
 
 		// Assuming $post_type to be product if empty
-		// Also make sure the orderby param affects only the main query
-		if ( $query->is_main_query() && ( empty( $post_type ) || 'product' === $post_type ) ) {
+		if ( empty( $post_type ) || 'product' === $post_type ) {
 
 			/**
 			 * Set orderby from GET param
+			 * Also make sure the orderby param affects only the main query
 			 */
-			if ( ! empty( $_GET['orderby'] ) ) {
+			if ( ! empty( $_GET['orderby'] ) && $query->is_main_query() ) {
 
 				switch ( $_GET['orderby'] ) {
 					case 'popularity':

--- a/elasticpress-woocommerce.php
+++ b/elasticpress-woocommerce.php
@@ -281,7 +281,9 @@ function epwc_translate_args( $query ) {
 		}
 
 		// Assuming $post_type to be product if empty
-		if ( empty( $post_type ) || 'product' === $post_type ) {
+		// Also make sure the orderby param affects only the main query
+		if ( $query->is_main_query() && ( empty( $post_type ) || 'product' === $post_type ) ) {
+
 			/**
 			 * Set orderby from GET param
 			 */

--- a/elasticpress-woocommerce.php
+++ b/elasticpress-woocommerce.php
@@ -309,13 +309,19 @@ function epwc_translate_args( $query ) {
 						$query->set( 'order', 'desc' );
 						break;
 					default:
-						$query->set( 'orderby', 'menu_order title date meta._price.long' ); // Order by menu and title.
+						$query->set( 'orderby', 'menu_order title date' ); // Order by menu and title.
 						$query->set( 'order', 'asc' );
 				}
 			} else {
-				$query->set( 'orderby', 'menu_order title date meta._price.long' ); // Order by menu and title.
-				$query->set( 'order', 'asc' );
+					$query->set( 'orderby', 'menu_order title date' ); // Order by menu and title.
+					$query->set( 'order', 'asc' );
 			}
+		} // Conditional check for orders
+		elseif ( in_array( $post_type, array( 'shop_order', 'shop_order_refund' ) ) || ( is_array( $post_type ) && ! array_diff( $post_type, $supported_post_types ) ) ) {
+			$query->set( 'order', 'desc' );
+		} elseif ( 'product_variation' === $post_type ) {
+			$query->set( 'orderby', 'menu_order' );
+			$query->set( 'order', 'asc' );
 		}
 
 		$orderby = $query->get( 'orderby' );


### PR DESCRIPTION
- Include child terms to the Elasticsearch query when querying a parent term of a hierarchical taxonomy
- Fix issue of product ordering
- Fixes https://github.com/10up/elasticpress-woocommerce/issues/3
- Handle WC widget queries.
