### PR TITLE
enabled composer compatibility with latest ElasticPress

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
         }
     ],
     "require": {
-        "10up/elasticpress": "^1.8"
+        "10up/elasticpress": ">=1.8"
     }
 }


### PR DESCRIPTION
Using the caret limits the requirement to 1.\* of elasticpress. This enables anything greater than or equal to 1.8. We'll also need to roll a new patch release, or create a new 1.2.1 tag.
