### PR TITLE
Fix for issue 31

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "10up/elasticpress-woocommerce",
     "description": "Extension for ElasticPress to handle WooCommerce",
-    "license": "GPLv2",
+    "license": "GPL-2.0",
     "type": "wordpress-plugin",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "10up/elasticpress-woocommerce",
     "description": "Extension for ElasticPress to handle WooCommerce",
     "license": "GPLv2",
+    "type": "wordpress-plugin",
     "authors": [
         {
             "name": "Taylor Lovett",


### PR DESCRIPTION
Fix for #31 
- Add `"type": "wordpress-plugin"` to composer.json
- Format license according to SPDX https://spdx.org/licenses/ to `GPL-2.0` 
